### PR TITLE
Add NewUserMailerGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Or install it yourself as:
 
 ## Usage
 
+### Generators
+
+* `rails g jefferies_tube:new_user_mailer`
+
+Creates `app/mailers/new_user_mailer.rb` and associated files. Mailer takes a user and sends a them a password reset link. Useful when you want to include other content for your new users that shouldn't be in the Devise password reset email.
+
 ### 404 Handling
 
 Jefferies Tube by default installs a catchall route that will render 404 for you and supress the rollbar error.  This also allows you to create super easy custom error pages.

--- a/lib/generators/jefferies_tube/new_user_mailer_generator.rb
+++ b/lib/generators/jefferies_tube/new_user_mailer_generator.rb
@@ -1,0 +1,11 @@
+module JefferiesTube
+  module Generators
+    class NewUserMailerGenerator < Rails::Generators::Base
+      desc "This generator creates a mailer to send your new users a link to reset their passwords"
+
+      def copy_mailer
+        copy_file 'new_user_mailer.rb', 'app/mailers/new_user_mailer.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/jefferies_tube/templates/new_user_mailer.rb
+++ b/lib/generators/jefferies_tube/templates/new_user_mailer.rb
@@ -1,0 +1,15 @@
+class NewUserMailer < ApplicationMailer
+
+  def user_password_reset(user)
+    @user = user
+    @raw_token, enc_token = Devise.token_generator.generate(User, :reset_password_token)
+    @user.update({
+      reset_password_token: enc_token,
+      reset_password_sent_at: Time.now
+    })
+    mail(
+      to: @user.email,
+      subject: 'Welcome! Please set your password'
+    )
+  end
+end


### PR DESCRIPTION
For some reason in both call_survey and habit_catalyst (where I've tried testing this), the generator errors out when I try to run it
```
call_survey|master⚡ ⇒ rails g jefferies_tube:new_user_mailer                                                                                                                                                                                  
[WARNING] Could not load generator "generators/jefferies_tube/new_user_mailer_generator". Error: uninitialized constant JefferiesTube::Rails::Generators.
/home/zach/Dropbox/tenforward/jefferies_tube/lib/generators/jefferies_tube/new_user_mailer_generator.rb:5:in `<module:Generators>'
/home/zach/Dropbox/tenforward/jefferies_tube/lib/generators/jefferies_tube/new_user_mailer_generator.rb:4:in `<module:JefferiesTube>'
/home/zach/Dropbox/tenforward/jefferies_tube/lib/generators/jefferies_tube/new_user_mailer_generator.rb:3:in `<top (required)>'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:332:in `block (2 levels) in lookup'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:328:in `each'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:328:in `block in lookup'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:327:in `each'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:327:in `lookup'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:138:in `find_by_namespace'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/generators.rb:155:in `invoke'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands/generate.rb:13:in `<top (required)>'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:123:in `require_command!'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:130:in `generate_or_destroy'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:50:in `generate'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
/home/zach/.rvm/gems/ruby-2.2.2@call-survey/gems/railties-4.2.3/lib/rails/commands.rb:17:in `<top (required)>'
/home/zach/Dropbox/tenforward/call_survey/bin/rails:8:in `<top (required)>'
/home/zach/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/home/zach/.rvm/rubies/ruby-2.2.2/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
-e:1:in `<main>'
Could not find generator 'jefferies_tube:new_user_mailer'. Maybe you meant 'test_unit:mailer', 'erb:mailer' or 'delayed_job:upgrade'
Run `rails generate --help` for more options.
```

But I've compared this to the simpleform gem and I can't find any discernible differences.