### PR TITLE
Don't use run_interactively to start ssh session. Bump version to 0.0.9

### DIFF
--- a/lib/jefferies_tube/capistrano/ssh.rb
+++ b/lib/jefferies_tube/capistrano/ssh.rb
@@ -1,6 +1,8 @@
 desc "Open an ssh session"
 task :ssh do
   on roles(:app), primary: true do |host|
-    run_interactively '/bin/bash'
+    port = host.port || 22
+    puts "ssh #{host.user}@#{host} -p #{port}"
+    exec "ssh #{host.user}@#{host} -p #{port}"
   end
 end

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,3 +1,3 @@
 module JefferiesTube
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
This was changed so the MOTD would appear to the user.
Using run_interactively to start /bin/bash caused the user not to see
it.