### PR TITLE
Fix ssh path when deploy_to doesn't match application name

### DIFF
--- a/lib/jefferies_tube/capistrano/ssh.rb
+++ b/lib/jefferies_tube/capistrano/ssh.rb
@@ -2,7 +2,7 @@ desc "Open an ssh session"
 task :ssh do
   on roles(:app), primary: true do |host|
     port = host.port || 22
-    cmd = %Q|ssh #{host.user}@#{host} -p #{port} -t "cd /u/apps/#{fetch :application}/current && exec bash -l"|
+    cmd = %Q|ssh #{host.user}@#{host} -p #{port} -t "cd #{fetch :deploy_to}/current && exec bash -l"|
     puts cmd
     exec cmd
   end


### PR DESCRIPTION
This happens for doorman