### PR TITLE
Match posts to / as 404

### DIFF
--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -17,6 +17,7 @@ module JefferiesTube
       rescue ActionController::RoutingError
         ::Rails.application.routes.append do
           match "*a" => "jefferies_tube/errors#render_404", via: [:get, :post, :put, :options]
+          match "/" => "jefferies_tube/errors#render_404", via: :post
         end
       end
     end


### PR DESCRIPTION
There are spambots that hit this and the `match '*a'` does not catch it
for reasons explained here:
https://github.com/tenforwardconsulting/habit_catalyst/pull/948#issuecomment-365646180