### PR TITLE
Check if there's a new version of an insecure gem before exploding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-This is a [changelog](https://keepachangelog.com/en/0.3.0/).
+This is a [changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project attempts to follow [semantic versioning](https://semver.org/)
+
+## Unreleased
+
+* enhancements
+  * The `deploy:scan_gems` Capistrano task now will not block deployments if there is not a newer
+    version of the insecure dependency available.
 
 ## 1.2
 


### PR DESCRIPTION
Addresses #42 

I haven't _super_ tested this but I think it works. 

---

# Testing

The next time we get an insecure gem, we should test this code out.

Change the Gemfile to include JT like so:
```ruby
gem 'jefferies_tube', git: 'https://github.com/tenforwardconsulting/jefferies_tube.git', branch: 'amp-check-gem-version'
```
Run `bundle install` and then run `cap dev deploy:scan_gems`.  

If the currently insecure gem happens to not have a fix out yet, then great, we've tested that code path.  If not, then we can checkout this branch and futz with the code a little bit to force it to hit that path.

Include local JT like so:
```ruby
gem 'jefferies_tube', path: '~/path/to/jefferies_tube'
```