### PR TITLE
Console with warning colors, better environment prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ end
 
 If you do this, don't forget to add `my.development.rb` to the gitignore file.
 
+### Terminal colors
+Changes the prompt color of your terminal. Shows Development environments in blue, Test in yellow, and Production in a scary red.
+Defaults to using the Rails env and Rails app class name, but configuration can be done in a Rails initializer like:
+```
+JefferiesTube.configure do |config|
+  config.environment = 'production' # If you're using a nonstandard env name but want colors.
+  config.prompt_name = 'ShortName' #For a shorter prompt name if you have a long app
+end
+```
+
 ## Contributing
 
 1. Fork it ( http://github.com/<my-github-username>/jefferies_tube/fork )

--- a/lib/jefferies_tube.rb
+++ b/lib/jefferies_tube.rb
@@ -3,4 +3,24 @@ require 'jefferies_tube/engine'
 
 module JefferiesTube
   require 'jefferies_tube/railtie' if defined?(Rails)
+
+  class << self
+    def configure
+      yield(configuration)
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+
+  class Configuration
+    attr_accessor :environment
+    attr_accessor :prompt_name
+
+    def initialize
+      @environment = ::Rails.env.downcase || nil
+      @prompt_name = ::Rails.application.class.parent_name
+    end
+  end
 end

--- a/lib/jefferies_tube.rb
+++ b/lib/jefferies_tube.rb
@@ -1,5 +1,5 @@
 require 'jefferies_tube/version'
-require 'jefferies_tube/engine'
+require 'jefferies_tube/engine' if defined?(Rails)
 
 module JefferiesTube
   require 'jefferies_tube/railtie' if defined?(Rails)
@@ -20,7 +20,7 @@ module JefferiesTube
 
     def initialize
       @environment = ::Rails.env.downcase || nil
-      @prompt_name = ::Rails.application.class.parent_name
+      @prompt_name = ::Rails.application.class.parent_name || nil
     end
   end
 end

--- a/lib/jefferies_tube/custom_prompts.irbrc.rb
+++ b/lib/jefferies_tube/custom_prompts.irbrc.rb
@@ -1,0 +1,31 @@
+rails_env = Rails.env.downcase
+
+if rails_env
+  color = "\e[0m" #Default to white text on no background
+  current_app = Rails.application.class.parent_name
+
+  # shorten some common long environment names
+  if rails_env == "development"
+    rails_env = "dev"
+    color = "\e[0;37m\e[1;44m" #White on blue
+  elsif rails_env == "test"
+    color = "\e[0;37m\e[1;43m" #White on yellow
+  elsif rails_env == "production"
+    rails_env = "prod"
+    color = "\e[0;37m\e[1;41m" #White on red
+  end 
+
+  base = "#{color}#{current_app}(#{rails_env})\e[0m"
+  prompt = base + "> "
+
+  IRB.conf[:PROMPT][:RAILS_ENV] = {   
+      :PROMPT_I => prompt,
+      :PROMPT_N => prompt,
+      :PROMPT_S => nil,
+      :PROMPT_C => base + ">* ",
+      :RETURN => "=> %s\n"
+  }
+
+  IRB.conf[:PROMPT_MODE] = :RAILS_ENV
+
+end

--- a/lib/jefferies_tube/custom_prompts.irbrc.rb
+++ b/lib/jefferies_tube/custom_prompts.irbrc.rb
@@ -1,8 +1,8 @@
-rails_env = Rails.env.downcase
+rails_env = JefferiesTube.configuration.environment
 
 if rails_env
   color = "\e[0m" #Default to white text on no background
-  current_app = Rails.application.class.parent_name
+  current_app = JefferiesTube.configuration.prompt_name
 
   # shorten some common long environment names
   if rails_env == "development"

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -7,6 +7,31 @@ module JefferiesTube
 
     console do
       ActiveRecord::Base.connection
+      ARGV.push "-r", File.join(File.dirname(__FILE__),"custom_prompts.irbrc.rb")
+      if defined? Pry
+        
+        puts 'Pry loaded'
+        
+        Pry.config.prompt = proc {
+          current_app = ::Rails.application.class.parent_name
+          rails_env = ::Rails.env.downcase
+          color = "\e[0m" #Default to white text on no background
+        
+          # shorten some common long environment names
+          if rails_env == "development"
+            rails_env = "dev"
+            color = "\e[0;37m\e[1;44m" #White on blue
+          elsif rails_env == "test"
+            color = "\e[0;37m\e[1;43m" #White on yellow
+          elsif rails_env == "production"
+            rails_env = "prod"
+            color = "\e[0;37m\e[1;41m" #White on red
+          end 
+        
+          base = "#{color}#{current_app}(#{rails_env})\e[0m"
+          prompt = base + "> "
+        }
+      end
     end
 
     config.after_initialize do |args|

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -2,33 +2,29 @@ require 'jefferies_tube'
 require 'rails'
 
 module JefferiesTube
+
   class Railtie < ::Rails::Railtie
     railtie_name :jefferies_tube
-
+    
     console do
       ActiveRecord::Base.connection
-      ARGV.push "-r", File.join(File.dirname(__FILE__),"custom_prompts.irbrc.rb")
-      if defined? Pry
-        
-        puts 'Pry loaded'
-        
+      unless defined? Pry
+        ARGV.push "-r", File.join(File.dirname(__FILE__),"custom_prompts.irbrc.rb")
+      end
+      
+      if defined? Pry        
         Pry.config.prompt = proc {
-          current_app = ::Rails.application.class.parent_name
-          rails_env = ::Rails.env.downcase
-          color = "\e[0m" #Default to white text on no background
+          current_app = JefferiesTube.configuration.prompt_name
+          rails_env = JefferiesTube.configuration.environment
         
           # shorten some common long environment names
           if rails_env == "development"
             rails_env = "dev"
-            color = "\e[0;37m\e[1;44m" #White on blue
-          elsif rails_env == "test"
-            color = "\e[0;37m\e[1;43m" #White on yellow
           elsif rails_env == "production"
             rails_env = "prod"
-            color = "\e[0;37m\e[1;41m" #White on red
           end 
         
-          base = "#{color}#{current_app}(#{rails_env})\e[0m"
+          base = "#{current_app}(#{rails_env})"
           prompt = base + "> "
         }
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../lib/jefferies_tube'
+require 'rails'
+
+
+RSpec.describe "Configuration" do
+  describe 'configuration' do
+    it 'allows the Environment name to be initialized' do
+      expect(JefferiesTube.configuration.environment).to_not be_nil
+    end
+
+    it 'allows a custom environment name & prompt' do
+      JefferiesTube.configure do |config|
+        config.environment = 'production' # If you're using a nonstandard env name but want colors.
+        config.prompt_name = 'ShortName' #For a shorter prompt name if you have a long app
+      end
+
+      expect(JefferiesTube.configuration.environment).to eq("production")
+      expect(JefferiesTube.configuration.prompt_name).to eq("ShortName")
+    end
+
+  end
+end


### PR DESCRIPTION
- Colors the IRB console based on RAILS_ENV, adds a helpful tick about the environment name
- Doesn't color Pry consoles, but replaces the prompt for local development

![image](https://user-images.githubusercontent.com/6099983/63055267-23c04900-beab-11e9-9c2b-dc372e240a2e.png)


![image](https://user-images.githubusercontent.com/6099983/63055275-27ec6680-beab-11e9-8758-0fe7ebe16069.png)


