### PR TITLE
Remove Style/IndentationConsistency and exclude any vendor RuboCops

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -3,8 +3,8 @@ require: rubocop-rails
 AllCops:
   DisabledByDefault: true
   SuggestExtensions: false
-Style/IndentationConsistency:
-  Enabled: true
+  Exclude:
+    - "vendor/**/*"
 
 Layout/LineLength:
   Max: 200


### PR DESCRIPTION
Style/IndentationConsistency seems to have been replaced by Layout/IndentationConsistency, which we already have enabled. 

Excluding vendor rubocops because of [an issue I encountered](https://github.com/tenforwardconsulting/brand_scope/actions/runs/4080000297/jobs/7031993556) while trying to rubocop Brandscope via github actions:

```
Error: RuboCop found unsupported Ruby version 1.9 in `TargetRubyVersion` parameter (in vendor/bundle/ruby/3.0.0/gems/airbrussh-1.4.1/.rubocop.yml). 1.9-compatible analysis was dropped after version 0.41.
Supported versions: 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2
RuboCop failed!
```