### PR TITLE
Support bundler-audit config file for ignoring CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.6.8
+  * Add support for ignoring CVEs in .bundler-audit.yml, remove support for setting ignored CVEs in deploy.rb via `:bundler_audit_ignore`
+
 ## 1.6.7
   * Add Lint/Syntax to rubocop rules
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,12 @@ before 'deploy', 'deploy:create_tag'
 
 By default jefferies_tube will raise an error and stop if it detects any vulnerabilities is your installed gems. If you need to deploy anyway even with vulnerabilities you can do `I_KNOW_GEMS_ARE_INSECURE=true cap <environment> deploy`.
 
-To ignore specific CVE's when running bundler-audit, inside `config/deploy.rb`:
-```ruby
-set :bundler_audit_ignore, ["CVE-1234-5678"]
+To ignore specific CVE's when running bundler-audit, add a .bundler-audit.yml file to your projets root directory, and ignore vulnerabilities like so:
+
+```yml
+---
+ignore:
+  - CVE-2024-6484
 ```
 
 ### Enable/Disable Maintence Mode

--- a/lib/jefferies_tube/capistrano/deploy.rb
+++ b/lib/jefferies_tube/capistrano/deploy.rb
@@ -30,8 +30,8 @@ namespace :deploy do
     Bundler::Audit::Database.update!
     scanner = Bundler::Audit::Scanner.new
     vulnerable = false
-    ignore = fetch(:bundler_audit_ignore, [])
-    scanner.scan(ignore: ignore) do |result|
+
+    scanner.scan do |result|
       vulnerable = true
       case result
       when Bundler::Audit::Results::InsecureSource

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.6.7"
+  VERSION = "1.6.8"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]


### PR DESCRIPTION
remove support for ignoring CVEs via :bundler_audit_ignore in deploy.rb, replace with ability to ignore CVEs in a .bundler-audit.yml config file