### PR TITLE
SimpleCov: Fix issue with simplecov starting twice when RAILS_ENV=test is specified when running default rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.6.9
+  * Refactor checking for JT_RSPEC environment variable when starting simplecov; prepends env var to rails application's spec_helper if
+    that line does not already exist.
+
 ## 1.6.8
   * Add support for ignoring CVEs in .bundler-audit.yml, remove support for setting ignored CVEs in deploy.rb via `:bundler_audit_ignore`
 

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -77,7 +77,19 @@ module JefferiesTube
     end
 
     initializer 'load simplecov for tests' do |config|
-      if ::Rails.env.test? && ENV['JT_RAKE']
+      existing_spec_helper = File.join(::Rails.root.join "spec", "spec_helper.rb" )
+      if !(File.open(existing_spec_helper, &:readline) == "ENV['JT_RSPEC'] = 'true'\n")
+        content = File.read(existing_spec_helper)
+        File.open(existing_spec_helper, "w") do |line|
+          line.puts "ENV['JT_RSPEC'] = 'true'"
+          line.puts "# ENV['JT_RSPEC'] = 'true' is required for correctly running SimpleCov via the jefferies_tube default rake task"
+          line.puts "\n"
+          line.puts content
+        end
+      end
+
+      if ::Rails.env.test? && ENV['JT_RSPEC'] == 'true'
+        ENV['JT_RSPEC'] = nil
         simplecov_config = 'config/simplecov.rb'
         require_relative simplecov_config
       end
@@ -88,7 +100,6 @@ module JefferiesTube
       if defined?(RSpec)
         require 'rspec/core/rake_task'
         task :jtspec do
-          ENV['JT_RAKE'] = "true"
           Rake::Task["spec"].invoke
         end
         task default: :jtspec

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.6.8"
+  VERSION = "1.6.9"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]


### PR DESCRIPTION
This is intended to address an issue with newer versions of tailwindcss-rails. When running the github actions RSpec workflow without specifying a rails environment, the workflow run errors out:
<img width="531" alt="Screenshot 2024-10-24 at 1 01 53 PM" src="https://github.com/user-attachments/assets/768f869e-d6c5-40f4-9874-9f3aefcdc8fc">

Specifying the Rails environment in the workflow prevents the error from occurring, but SimpleCov runs twice for some reason and fails the second time, which also results in a failed workflow:
<img width="275" alt="Screenshot 2024-10-24 at 1 02 20 PM" src="https://github.com/user-attachments/assets/251247a3-c963-47d9-99c7-55ab4ed31eaf">

This PR ensures that SimpleCov is only started if the `JT_RSPEC` env var is set to true, which now happens in the Rails app's `spec_helper.rb` at the top of the file. JT will check to see if that line is declared in `spec_helper`, and if not, it prepends it to the file.
