### PR TITLE
Add ERB versions of 404 and 500 pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.7.2
+  * Bugfix: update 404 and 500 pages to have .html.erb variants, not just .haml
+
 ## 1.7.1
   * Bugfix: change `exists?` to `exist?` and check for `existing_spec_helper` file
   * Update robocop rules

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>404: <%= request.fullpath %></title>
+    <style>
+      #jt-error {
+        margin: 32px auto; padding: 32px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="jt-error">
+      <p>Sorry!  We couldn't find the page you were looking for :(</p>
+    </div>
+  </body>
+</html>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <title>500: <%= request.fullpath %></title>
+    <style>
+      #jt-error {
+        margin: 32px auto; padding: 32px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="jt-error">
+      <p>Sorry!  Something went wrong with our server. Our development team has been notified.</p>
+      <p><%= "Error Code: 500 (#{@exception.class.name})" %></p>
+    </div>
+  </body>
+</html>

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]


### PR DESCRIPTION
The existing 404 and 500 views are in haml, which not all of our projects use