### PR TITLE
BUGFIX: change 'exists' to 'exist'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.7.3
+  * Bugfix: change `exists?` to `exist?` in `s3_assets.rb`
+
 ## 1.7.2
   * Bugfix: update 404 and 500 pages to have .html.erb variants, not just .haml
 

--- a/lib/jefferies_tube/capistrano/s3_assets.rb
+++ b/lib/jefferies_tube/capistrano/s3_assets.rb
@@ -4,10 +4,10 @@ task :upload_assets_to_s3 do
       appyml_text = capture :cat, "#{deploy_to}/shared/config/application.yml"
       appyml = YAML.load appyml_text
       execute "AWS_ACCESS_KEY_ID=#{appyml['AWS_ACCESS_KEY_ID']}", "AWS_SECRET_ACCESS_KEY=#{appyml["AWS_SECRET_ACCESS_KEY"]}", 'aws', 's3', 'sync', 'public/assets/', "#{fetch(:s3_destination)}/assets"
-      if Dir.exists?('public/static_assets')
+      if Dir.exist?('public/static_assets')
         execute "AWS_ACCESS_KEY_ID=#{appyml['AWS_ACCESS_KEY_ID']}", "AWS_SECRET_ACCESS_KEY=#{appyml["AWS_SECRET_ACCESS_KEY"]}", 'aws', 's3', 'sync', 'public/static_assets/', "#{fetch(:s3_destination)}/static_assets"
       end
-      if Dir.exists?('public/packs')
+      if Dir.exist?('public/packs')
         execute "AWS_ACCESS_KEY_ID=#{appyml['AWS_ACCESS_KEY_ID']}", "AWS_SECRET_ACCESS_KEY=#{appyml["AWS_SECRET_ACCESS_KEY"]}", 'aws', 's3', 'sync', 'public/packs/', "#{fetch(:s3_destination)}/packs"
       end
     end
@@ -28,7 +28,7 @@ task :copy_assets_manifest do
     manifest_name = capture(:ls, assets_path.join('.sprockets-manifest*')).strip
     manifest_contents = download! assets_path.join(manifest_name)
     within release_path do
-      webpack_enabled = Dir.exists?('public/packs')
+      webpack_enabled = Dir.exist?('public/packs')
     end
     if webpack_enabled
       packs_manifest_name = capture(:ls, packs_path.join('manifest.json')).strip

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.7.2"
+  VERSION = "1.7.3"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]


### PR DESCRIPTION
`exists` was removed from Ruby 3.2 and CRS is failing to deploy because of it