### PR TITLE
Default Rake task - do rails test if Rspec not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.7.4
+  * If RSpec is not defined, run `rails test` and `rails test:system` in default rake task
+
 ## 1.7.3
   * Bugfix: change `exists?` to `exist?` in `s3_assets.rb`
 

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -103,7 +103,10 @@ module JefferiesTube
           Rake::Task["spec"].invoke
         end
         task default: :jtspec
+      else
+        task default: ["test", "test:system"]
       end
+
       require 'rubocop/rake_task'
 
       if Object.const_defined?("DEBUGGER__")

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -103,8 +103,17 @@ module JefferiesTube
           Rake::Task["spec"].invoke
         end
         task default: :jtspec
-      else
-        task default: ["test", "test:system"]
+      end
+
+      if defined?(Minitest)
+        task :jtspec do
+          Rake::Task["test"].invoke
+
+          if Rake::Task.task_defined?("test:system")
+            Rake::Task["test:system"].invoke
+          end
+        end
+        task default: :jtspec
       end
 
       require 'rubocop/rake_task'

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.7.3"
+  VERSION = "1.7.4"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]


### PR DESCRIPTION
If RSpec is not defined, assume that project uses default rails test framework and add appropriate tasks to default rake task