### PR TITLE
Add parallel_tests support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.8.0
+  * Add parallel_tests support: when parallel_tests gem is present, default rake task automatically runs specs in parallel with collated SimpleCov coverage
+  * Extract coverage reporting into `JefferiesTube::Coverage.print_report`
+  * Suppress NewRelic configuration log message in test environment
+
 ## 1.7.9
   * Configure NewRelic to ignore invalid request errors caught by InvaildRequestHandler middleware
 

--- a/README.md
+++ b/README.md
@@ -241,3 +241,48 @@ Our Rubocop rules are built from the ground up to ensure the rules are all "actu
   [semver](https://semver.org/)).
 - Update `CHANGELOG.md` and move everything in 'Unreleased' to a new section for the new version.
 - Tag the final commit in that release.
+
+## Supporting parallel_tests
+
+When the `parallel_tests` gem is in your bundle, JefferiesTube automatically runs specs in parallel via the default `rake` task. Coverage is collected per-worker and collated at the end.
+
+### Setup
+
+Add `parallel_tests` to your Gemfile:
+
+```ruby
+group :development, :test do
+  gem 'parallel_tests'
+end
+```
+
+Update `config/database.yml` to use numbered test databases:
+
+```yaml
+test:
+  <<: *default
+  database: my_app_test<%= ENV['TEST_ENV_NUMBER'] %>
+```
+
+This creates databases like `my_app_test`, `my_app_test2`, `my_app_test3`, etc. JefferiesTube handles creating and preparing these automatically.
+
+Then just run `rake` — parallel tests, coverage, and rubocop will all run automatically.
+
+### Troubleshooting
+
+**Shared examples not found:** If you define shared examples in spec files (e.g. `spec/models/concerns/`), other parallel workers won't have them loaded. Ensure they're required in `rails_helper.rb`:
+
+```ruby
+Dir[Rails.root.join('spec', 'models', 'concerns', '**', '*.rb')].sort.each { |f| require f }
+```
+
+**Capybara port conflicts:** If Capybara is configured with a hardcoded port, multiple workers will collide. Remove `Capybara.app_host` and `Capybara.server_port` settings and let Capybara auto-assign ports:
+
+```ruby
+# Remove these lines:
+# Capybara.app_host = "http://localhost:3333"
+# Capybara.server_port = "3333"
+
+# Keep only:
+Capybara.server_host = "localhost"
+```

--- a/lib/jefferies_tube/config/simplecov.rb
+++ b/lib/jefferies_tube/config/simplecov.rb
@@ -1,24 +1,6 @@
 require 'simplecov'
 SimpleCov.start do
-  add_filter '/test/'
-  add_filter '/config/'
-
-  formatter SimpleCov::Formatter::HTMLFormatter
-
-  add_group 'Controllers' do |src_file|
-    src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
-  end
-  add_group 'API Controllers' do |src_file|
-    src_file.filename.include?('app/controllers') && src_file.filename.include?('api')
-  end
-  add_group 'Models', 'app/models'
-  add_group 'Services', 'app/services'
-  add_group 'Helpers', 'app/helpers'
-  add_group 'Policies', 'app/policies'
-  add_group 'Jobs', 'app/jobs'
-  add_group 'Mailers', 'app/mailers'
-  add_group 'Libraries', 'lib'
-  add_group 'Plugins', 'vendor/plugins'
+  JefferiesTube::Coverage.configure(self)
 end
 SimpleCov.at_exit do
   SimpleCov.result.format!

--- a/lib/jefferies_tube/config/simplecov_parallel.rb
+++ b/lib/jefferies_tube/config/simplecov_parallel.rb
@@ -2,22 +2,7 @@ require 'simplecov'
 
 test_env = ENV['TEST_ENV_NUMBER'].to_s.empty? ? '1' : ENV['TEST_ENV_NUMBER']
 SimpleCov.command_name "rspec_#{test_env}"
+SimpleCov.coverage_dir "coverage/worker_#{test_env}"
 SimpleCov.start do
-  add_filter '/test/'
-  add_filter '/config/'
-  formatter SimpleCov::Formatter::HTMLFormatter
-  add_group 'Controllers' do |src_file|
-    src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
-  end
-  add_group 'API Controllers' do |src_file|
-    src_file.filename.include?('app/controllers') && src_file.filename.include?('api')
-  end
-  add_group 'Models', 'app/models'
-  add_group 'Services', 'app/services'
-  add_group 'Helpers', 'app/helpers'
-  add_group 'Policies', 'app/policies'
-  add_group 'Jobs', 'app/jobs'
-  add_group 'Mailers', 'app/mailers'
-  add_group 'Libraries', 'lib'
-  add_group 'Plugins', 'vendor/plugins'
+  JefferiesTube::Coverage.configure(self)
 end

--- a/lib/jefferies_tube/config/simplecov_parallel.rb
+++ b/lib/jefferies_tube/config/simplecov_parallel.rb
@@ -1,10 +1,11 @@
 require 'simplecov'
+
+test_env = ENV['TEST_ENV_NUMBER'].to_s.empty? ? '1' : ENV['TEST_ENV_NUMBER']
+SimpleCov.command_name "rspec_#{test_env}"
 SimpleCov.start do
   add_filter '/test/'
   add_filter '/config/'
-
   formatter SimpleCov::Formatter::HTMLFormatter
-
   add_group 'Controllers' do |src_file|
     src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
   end
@@ -19,11 +20,4 @@ SimpleCov.start do
   add_group 'Mailers', 'app/mailers'
   add_group 'Libraries', 'lib'
   add_group 'Plugins', 'vendor/plugins'
-end
-SimpleCov.at_exit do
-  SimpleCov.result.format!
-  overall_failed = JefferiesTube::Coverage.print_report(SimpleCov.result)
-  if overall_failed
-    exit(SimpleCov::ExitCodes::MINIMUM_COVERAGE)
-  end
 end

--- a/lib/jefferies_tube/coverage.rb
+++ b/lib/jefferies_tube/coverage.rb
@@ -22,4 +22,30 @@ module JefferiesTube::Coverage
   def self.required_coverage
     self.default_converage.merge(@required_coverage || {})
   end
+
+  def self.print_report(result)
+    output = "=====================Test Coverage=====================\n"
+    output << "Group            Files       Current / Required (Ideal)\n"
+    overall_failed = false
+    result.groups.each do |name, group|
+      next if group.size.zero?
+      failed = group.covered_percent.round(2) < required_coverage[name]
+      warning = !failed && group.covered_percent.round(2) < default_converage[name]
+      overall_failed = true if failed
+      color = if failed
+        "\e[31m"
+      elsif warning
+        "\e[33m"
+      else
+        "\e[32m"
+      end
+      files = "Files: #{group.size}".ljust(11)
+      current = "#{group.covered_percent.round(2)}%".ljust(7)
+      required = "#{required_coverage[name]}%".ljust(8)
+      output << "#{color}#{name.ljust(16)} #{files} #{current} / #{required} (#{default_converage[name]}%)\e[0m\n"
+    end
+    output += "\n"
+    puts output
+    overall_failed
+  end
 end

--- a/lib/jefferies_tube/coverage.rb
+++ b/lib/jefferies_tube/coverage.rb
@@ -23,6 +23,27 @@ module JefferiesTube::Coverage
     self.default_converage.merge(@required_coverage || {})
   end
 
+  def self.configure(config)
+    config.add_filter '/test/'
+    config.add_filter '/spec/'
+    config.add_filter '/config/'
+    config.formatter SimpleCov::Formatter::HTMLFormatter
+    config.add_group 'Controllers' do |src_file|
+      src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
+    end
+    config.add_group 'API Controllers' do |src_file|
+      src_file.filename.include?('app/controllers') && src_file.filename.include?('api')
+    end
+    config.add_group 'Models', 'app/models'
+    config.add_group 'Services', 'app/services'
+    config.add_group 'Helpers', 'app/helpers'
+    config.add_group 'Policies', 'app/policies'
+    config.add_group 'Jobs', 'app/jobs'
+    config.add_group 'Mailers', 'app/mailers'
+    config.add_group 'Libraries', 'lib'
+    config.add_group 'Plugins', 'vendor/plugins'
+  end
+
   def self.print_report(result)
     output = "=====================Test Coverage=====================\n"
     output << "Group            Files       Current / Required (Ideal)\n"

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -89,7 +89,11 @@ module JefferiesTube
         end
       end
 
-      if ::Rails.env.test? && ENV['JT_RSPEC'] == 'true'
+      if ::Rails.env.test? && ENV['TEST_ENV_NUMBER'] && ENV['JT_RSPEC'] == 'true'
+        ::Rails.configuration.eager_load = true
+        ENV['JT_RSPEC'] = nil
+        require_relative 'config/simplecov_parallel'
+      elsif ::Rails.env.test? && ENV['JT_RSPEC'] == 'true'
         ::Rails.configuration.eager_load = true
         ENV['JT_RSPEC'] = nil
         simplecov_config = 'config/simplecov.rb'
@@ -106,7 +110,7 @@ module JefferiesTube
     config.after_initialize do
       if defined?(NewRelic::Agent) && NewRelic::Agent.respond_to?(:ignore_error_filter)
         existing_filter = NewRelic::Agent::ErrorCollector.ignore_error_filter
-        puts "[JefferiesTube] Configuring NewRelic ignore_error_filter for invalid request errors"
+        puts "[JefferiesTube] Configuring NewRelic ignore_error_filter for invalid request errors" unless ::Rails.env.test?
 
         NewRelic::Agent.ignore_error_filter do |error|
           keep = case error

--- a/lib/jefferies_tube/railtie.rb
+++ b/lib/jefferies_tube/railtie.rb
@@ -133,37 +133,5 @@ module JefferiesTube
           "Invalid request errors may still be reported to NewRelic."
       end
     end
-
-    rake_tasks do
-      task(:default).clear
-      if defined?(RSpec)
-        require 'rspec/core/rake_task'
-        task :jtspec do
-          Rake::Task["spec"].invoke
-        end
-        task default: :jtspec
-      elsif defined?(Minitest)
-        task :jtspec do
-          Rake::Task["test"].invoke
-
-          if Rake::Task.task_defined?("test:system")
-            Rake::Task["test:system"].invoke
-          end
-        end
-        task default: :jtspec
-      end
-
-      require 'rubocop/rake_task'
-
-      if Object.const_defined?("DEBUGGER__")
-        DEBUGGER__.class_eval do
-          def self.warn(msg)
-          end
-        end
-      end
-
-      RuboCop::RakeTask.new(:rubocop)
-      task default: :rubocop
-    end
   end
 end

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.7.9"
+  VERSION = "1.8.0"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,3 +1,33 @@
+task(:default).clear
+
+if Gem.loaded_specs.key?('rspec-core')
+  require 'rspec/core/rake_task'
+  task :jtspec do
+    Rake::Task["spec"].invoke
+  end
+  task default: :jtspec
+elsif Gem.loaded_specs.key?('minitest')
+  task :jtspec do
+    Rake::Task["test"].invoke
+    if Rake::Task.task_defined?("test:system")
+      Rake::Task["test:system"].invoke
+    end
+  end
+  task default: :jtspec
+end
+
+require 'rubocop/rake_task'
+
+if Object.const_defined?("DEBUGGER__")
+  DEBUGGER__.class_eval do
+    def self.warn(msg)
+    end
+  end
+end
+
+RuboCop::RakeTask.new(:rubocop)
+task default: :rubocop
+
 if Gem.loaded_specs.key?('parallel_tests')
   Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
   Rake::Task[:jtspec].clear if Rake::Task.task_defined?(:jtspec)
@@ -5,7 +35,9 @@ if Gem.loaded_specs.key?('parallel_tests')
   task :jtspec do
     Rake::Task["parallel:clear_coverage"].invoke
     Rake::Task["parallel:prepare"].invoke
+    ENV['JT_RSPEC'] = 'true'
     Rake::Task["parallel:spec"].invoke
+    ENV['JT_RSPEC'] = nil
     Rake::Task["parallel:collate_coverage"].invoke
   end
 
@@ -21,24 +53,8 @@ if Gem.loaded_specs.key?('parallel_tests')
     desc "Collate SimpleCov results from parallel test runs"
     task collate_coverage: :environment do
       require 'simplecov'
-      SimpleCov.collate Dir["coverage/.resultset.json"] do
-        formatter SimpleCov::Formatter::HTMLFormatter
-        add_filter '/test/'
-        add_filter '/config/'
-        add_group 'Controllers' do |src_file|
-          src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
-        end
-        add_group 'API Controllers' do |src_file|
-          src_file.filename.include?('app/controllers') && src_file.filename.include?('api')
-        end
-        add_group 'Models', 'app/models'
-        add_group 'Services', 'app/services'
-        add_group 'Helpers', 'app/helpers'
-        add_group 'Policies', 'app/policies'
-        add_group 'Jobs', 'app/jobs'
-        add_group 'Mailers', 'app/mailers'
-        add_group 'Libraries', 'lib'
-        add_group 'Plugins', 'vendor/plugins'
+      SimpleCov.collate Dir["coverage/worker_*/.resultset.json"] do
+        JefferiesTube::Coverage.configure(self)
       end
 
       overall_failed = JefferiesTube::Coverage.print_report(SimpleCov.result)

--- a/lib/tasks/parallel.rake
+++ b/lib/tasks/parallel.rake
@@ -1,0 +1,51 @@
+if Gem.loaded_specs.key?('parallel_tests')
+  Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+  Rake::Task[:jtspec].clear if Rake::Task.task_defined?(:jtspec)
+
+  task :jtspec do
+    Rake::Task["parallel:clear_coverage"].invoke
+    Rake::Task["parallel:prepare"].invoke
+    Rake::Task["parallel:spec"].invoke
+    Rake::Task["parallel:collate_coverage"].invoke
+  end
+
+  task default: :jtspec
+  task default: :rubocop
+
+  namespace :parallel do
+    desc "Clear stale coverage data before parallel test run"
+    task :clear_coverage do
+      FileUtils.rm_rf("coverage")
+    end
+
+    desc "Collate SimpleCov results from parallel test runs"
+    task collate_coverage: :environment do
+      require 'simplecov'
+      SimpleCov.collate Dir["coverage/.resultset.json"] do
+        formatter SimpleCov::Formatter::HTMLFormatter
+        add_filter '/test/'
+        add_filter '/config/'
+        add_group 'Controllers' do |src_file|
+          src_file.filename.include?('app/controllers') && !src_file.filename.include?('api')
+        end
+        add_group 'API Controllers' do |src_file|
+          src_file.filename.include?('app/controllers') && src_file.filename.include?('api')
+        end
+        add_group 'Models', 'app/models'
+        add_group 'Services', 'app/services'
+        add_group 'Helpers', 'app/helpers'
+        add_group 'Policies', 'app/policies'
+        add_group 'Jobs', 'app/jobs'
+        add_group 'Mailers', 'app/mailers'
+        add_group 'Libraries', 'lib'
+        add_group 'Plugins', 'vendor/plugins'
+      end
+
+      overall_failed = JefferiesTube::Coverage.print_report(SimpleCov.result)
+
+      if overall_failed
+        exit(SimpleCov::ExitCodes::MINIMUM_COVERAGE)
+      end
+    end
+  end
+end

--- a/spec/coverage_spec.rb
+++ b/spec/coverage_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../lib/jefferies_tube/coverage'
+
+RSpec.describe JefferiesTube::Coverage do
+  describe '.print_report' do
+    let(:group) do
+      instance_double('SimpleCov::FileList', size: 5, covered_percent: covered_percent)
+    end
+    let(:result) { instance_double('SimpleCov::Result', groups: {'Models' => group}) }
+
+    before do
+      allow(described_class).to receive(:puts)
+      described_class.required_coverage = nil
+    end
+
+    context 'when coverage meets the required threshold' do
+      let(:covered_percent) { 100.0 }
+
+      it 'returns false' do
+        expect(described_class.print_report(result)).to eq(false)
+      end
+    end
+
+    context 'when coverage is below the required threshold' do
+      let(:covered_percent) { 50.0 }
+
+      it 'returns true' do
+        expect(described_class.print_report(result)).to eq(true)
+      end
+    end
+
+    context 'when coverage meets required but is below default' do
+      let(:covered_percent) { 80.0 }
+
+      before do
+        described_class.required_coverage = {'Models' => 75}
+      end
+
+      it 'returns false' do
+        expect(described_class.print_report(result)).to eq(false)
+      end
+    end
+
+    context 'when group has zero files' do
+      let(:empty_group) { instance_double('SimpleCov::FileList', size: 0) }
+      let(:result) { instance_double('SimpleCov::Result', groups: {'Models' => empty_group}) }
+
+      it 'skips the group and returns false' do
+        expect(described_class.print_report(result)).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- When `parallel_tests` gem is in the bundle, the default rake task automatically runs specs in parallel with collated SimpleCov coverage
- Extracts coverage reporting into `JefferiesTube::Coverage.print_report` to eliminate duplication
- Adds `simplecov_parallel.rb` config for per-worker coverage collection without `at_exit` reports
- Suppresses NewRelic configuration log message in test environment

## Usage
Add `parallel_tests` to your Gemfile and update `database.yml` to append `TEST_ENV_NUMBER` to the test database name:

```yaml
test:
  <<: *default
  database: my_app_test<%= ENV['TEST_ENV_NUMBER'] %>
```

This creates numbered databases for each parallel worker (e.g. `my_app_test`, `my_app_test2`, `my_app_test3`, etc.).

Then just run `rake` — it will automatically use parallel processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)