### PR TITLE
Fix ArgumentError on rendered error pages under Rails 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project attempts to follow [semantic versioning](https://semver.org/)
 
 ## Unreleased
 
+## 1.7.10
+  * Bugfix: fix `ArgumentError` raised by `ErrorsController` on every rendered error page under Rails 8. `_layout`'s arity changed across Rails versions, so build its arguments from the method's actual parameters instead of hardcoding a count (supports Rails 6.1–8+).
+  * Declare a minimum `rails` dependency of `>= 6.1.7.9`.
+  * Remove dead code: the Rails 3 `before_filter` branch, the unused `html_layout` and `additional_information` methods, and a pre-Rails-6 `prompt_name` fallback.
+
 ## 1.7.9
   * Configure NewRelic to ignore invalid request errors caught by InvaildRequestHandler middleware
 

--- a/app/controllers/jefferies_tube/errors_controller.rb
+++ b/app/controllers/jefferies_tube/errors_controller.rb
@@ -38,10 +38,6 @@ class JefferiesTube::ErrorsController < ApplicationController
     !!resolve_layout([request.format.to_sym])
   end
 
-  # Invokes the private `_layout` for the given formats. Its signature has
-  # changed across Rails versions (`(formats, keys)` in 6.1–7,
-  # `(lookup_context, formats, keys)` in 8+), so build the argument list by
-  # matching the method's actual parameter names instead of hardcoding a count.
   def resolve_layout(formats)
     args = JefferiesTube::LayoutArgs.for(
       self.method(:_layout).parameters,

--- a/app/controllers/jefferies_tube/errors_controller.rb
+++ b/app/controllers/jefferies_tube/errors_controller.rb
@@ -1,20 +1,10 @@
 class JefferiesTube::ErrorsController < ApplicationController
-  if Rails.version.start_with? "3"
-    before_filter :disable_pundit
-    skip_before_filter :verify_authenticity_token
-  else
-    before_action :disable_pundit
-    skip_before_action :verify_authenticity_token
-  end
+  before_action :disable_pundit
+  skip_before_action :verify_authenticity_token
 
   def render_404
     log_404
     render_error_page 404
-  end
-
-  def additional_information
-    # TODO not implemented yet
-    render text: "Thanks!", layout: has_app_layout?
   end
 
   private
@@ -45,20 +35,19 @@ class JefferiesTube::ErrorsController < ApplicationController
   end
 
   def has_app_layout?
-    if Gem::Version.new(Rails.version) >= Gem::Version.new("5")
-      !!self.send(:_layout, [request.format.to_sym])
-    else
-      # boolean based on if there is a default layout for the current mime type
-      !!self.send(:_layout)
-    end
+    !!resolve_layout([request.format.to_sym])
   end
 
-  def html_layout
-    if Gem::Version.new(Rails.version) >= Gem::Version.new("5")
-      self.send(:_layout, ["html"]).virtual_path
-    else
-      # boolean based on if there is a default layout for the current mime type
-      "application"
-    end
+  # Invokes the private `_layout` for the given formats. Its signature has
+  # changed across Rails versions (`(formats, keys)` in 6.1–7,
+  # `(lookup_context, formats, keys)` in 8+), so build the argument list by
+  # matching the method's actual parameter names instead of hardcoding a count.
+  def resolve_layout(formats)
+    args = JefferiesTube::LayoutArgs.for(
+      self.method(:_layout).parameters,
+      lookup_context: lookup_context,
+      formats: formats
+    )
+    self.send(:_layout, *args)
   end
 end

--- a/jefferies_tube.gemspec
+++ b/jefferies_tube.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", '~> 13.0.6'
   spec.add_development_dependency "rspec", '~> 3.0'
 
+  spec.add_dependency 'rails', '>= 6.1.7.9'
   spec.add_dependency "bundler-audit", "~> 0.9"
   spec.add_dependency "pry", '~> 0.13'
   spec.add_dependency 'rubocop', '~> 1.26'

--- a/lib/jefferies_tube.rb
+++ b/lib/jefferies_tube.rb
@@ -1,4 +1,5 @@
 require 'jefferies_tube/version'
+require 'jefferies_tube/layout_args'
 require 'jefferies_tube/engine' if defined?(Rails)
 
 module JefferiesTube
@@ -21,12 +22,7 @@ module JefferiesTube
     def initialize
       if defined?(Rails)
         @environment = ::Rails.env.downcase || nil
-        @prompt_name =
-          if ::Rails::VERSION::MAJOR >= 6
-            ::Rails.application.class.module_parent_name || nil
-          else
-            ::Rails.application.class.parent_name || nil
-          end
+        @prompt_name = ::Rails.application.class.module_parent_name || nil
       else
         @environment = "development"
         @prompt_name = "JefferiesTube"

--- a/lib/jefferies_tube/layout_args.rb
+++ b/lib/jefferies_tube/layout_args.rb
@@ -1,0 +1,26 @@
+module JefferiesTube
+  # Builds the positional argument list for ActionView's private `_layout`
+  # method, whose signature has changed across Rails versions:
+  #
+  #   * 6.1–7.x:  _layout(formats, keys)
+  #   * 8.0+:     _layout(lookup_context, formats, keys)
+  #
+  # Rather than hardcode a count (which breaks on every version we did not
+  # anticipate), map the method's actual parameter names to the values we
+  # have. Unknown parameter names fall back to `formats` so a future
+  # signature change still receives the formats it expects.
+  module LayoutArgs
+    KNOWN = %i[lookup_context formats keys].freeze
+
+    # @param parameters [Array] the result of `method(:_layout).parameters`
+    # @param lookup_context the controller's lookup_context
+    # @param formats [Array] e.g. [:html]
+    # @return [Array] positional args to splat into `_layout`
+    def self.for(parameters, lookup_context:, formats:)
+      available = { lookup_context: lookup_context, formats: formats, keys: [] }
+      parameters.map do |_type, name|
+        available.fetch(name, formats)
+      end
+    end
+  end
+end

--- a/lib/jefferies_tube/version.rb
+++ b/lib/jefferies_tube/version.rb
@@ -1,7 +1,7 @@
 require 'open-uri'
 
 module JefferiesTube
-  VERSION = "1.7.9"
+  VERSION = "1.7.10"
 
   def self.latest_rubygems_version
     JSON.parse(URI.parse("https://rubygems.org/api/v1/versions/jefferies_tube/latest.json").read)["version"]

--- a/spec/layout_args_spec.rb
+++ b/spec/layout_args_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../lib/jefferies_tube/layout_args'
+
+RSpec.describe JefferiesTube::LayoutArgs do
+  let(:lookup_context) { Object.new }
+  let(:formats) { [:html] }
+
+  def build(parameters)
+    described_class.for(parameters, lookup_context: lookup_context, formats: formats)
+  end
+
+  context "Rails 8+ signature: _layout(lookup_context, formats, keys)" do
+    let(:parameters) { [[:req, :lookup_context], [:req, :formats], [:req, :keys]] }
+
+    it "returns three args in declared order" do
+      expect(build(parameters)).to eq([lookup_context, formats, []])
+    end
+  end
+
+  context "Rails 5.1–7 signature: _layout(formats, keys)" do
+    let(:parameters) { [[:req, :formats], [:req, :keys]] }
+
+    it "returns formats and keys, without lookup_context" do
+      expect(build(parameters)).to eq([formats, []])
+    end
+  end
+
+  context "unknown parameter name" do
+    let(:parameters) { [[:req, :something_new]] }
+
+    it "falls back to formats so the call still receives a sensible value" do
+      expect(build(parameters)).to eq([formats])
+    end
+  end
+
+  it "matches the number of arguments to the method's arity" do
+    [
+      [[:req, :lookup_context], [:req, :formats], [:req, :keys]],
+      [[:req, :formats], [:req, :keys]]
+    ].each do |params|
+      expect(build(params).size).to eq(params.size)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`JefferiesTube::ErrorsController` calls the private `_layout` method with a hardcoded argument count. That method's arity has changed across Rails versions:

* **6.1–7.x:** `_layout(formats, keys)`
* **8.0+:** `_layout(lookup_context, formats, keys)`

Under Rails 8, `has_app_layout?` calls `_layout` with the wrong number of arguments, raising `ArgumentError: wrong number of arguments` on **every rendered error page** (404/406/etc.). A bare `rescue` in `render_error_page` swallows it and falls back to `layout: false`, so pages still render — but the error is reported to NewRelic *first*. In one downstream app this was the single highest-volume error in the inbox (563 occurrences / 30 days).

## Fix

Build `_layout`'s argument list from the method's **actual parameter names** instead of hardcoding a count, so it adapts to whatever signature the installed Rails defines. The logic lives in a new, pure-Ruby `JefferiesTube::LayoutArgs` helper with unit coverage for both the 6.1–7 and 8+ signatures (plus a forward-compatible fallback).

## Also in this PR

* Declare a minimum `rails` dependency of `>= 6.1.7.9` (the gemspec previously declared no Rails dependency at all).
* Remove dead code now that pre-6.1 Rails is unsupported:
  * the Rails 3 `before_filter` / `skip_before_filter` branch
  * the unused `html_layout` method (private, never called)
  * the unused `additional_information` action (unrouted, and used `render text:` which was removed in Rails 5)
  * the pre-Rails-6 `parent_name` fallback in `prompt_name`
* CHANGELOG + version bump to `1.7.10`.

## Verification

* Gem specs: 13 examples, 0 failures.
* Verified end-to-end against a Rails 8.1.3 app: error/404/scanner paths render correct status codes with **zero arity errors reported to NewRelic**, and the authenticated 404 page renders within the application layout (confirmed in-browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)